### PR TITLE
fix composer requirements for php7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   },
   "require": {
-    "php": "~5.3",
+    "php": ">=5.3",
     "intervention/image": "~2.2"
   },
   "suggest": {


### PR DESCRIPTION
Using ~5.3 prevents on using marijnvdwerf/material-palette-php on PHP7, si we use >= to avoid that.
