### PR TITLE
Palette::findMaxPopulation() returns null for no swatches

### DIFF
--- a/src/Palette.php
+++ b/src/Palette.php
@@ -76,6 +76,9 @@ class Palette
 
     private function findMaxPopulation()
     {
+        if (!$this->swatches) {
+            return null;
+        }
         return max(array_map(function (Swatch $swatch) {
             return $swatch->getPopulation();
         }, $this->swatches));


### PR DESCRIPTION
Hi,

this patch fixes fatal error in PHP 8.0

```
ValueError: max(): Argument #1 ($value) must contain at least one element in /www/doc/myapp/vendor/marijnvdwerf/material-palette/src/Palette.php:81
```